### PR TITLE
fixes table name issue for nil namespace variable in config

### DIFF
--- a/lib/dynamoid/persistence.rb
+++ b/lib/dynamoid/persistence.rb
@@ -16,7 +16,10 @@ module Dynamoid
     module ClassMethods
 
       def table_name
-        @table_name ||= "#{Dynamoid::Config.namespace}_#{options[:name] || base_class.name.split('::').last.downcase.pluralize}"
+        table_base_name = options[:name] || base_class.name.split('::').last
+        .downcase.pluralize
+
+        @table_name ||= [Dynamoid::Config.namespace.to_s, table_base_name].reject(&:empty?).join('_')
       end
 
       # Creates a table.


### PR DESCRIPTION
If "config.namespace = nil" in initializes then table name becomes "_tableName".
I took fix from original branch and put in this fork.